### PR TITLE
Use APIService `v1` instead of `v1beta1`

### DIFF
--- a/pkg/debug_operator.go
+++ b/pkg/debug_operator.go
@@ -37,6 +37,9 @@ func NewCmdDebugOperator() *cobra.Command {
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dbgr := debugger.NewDebugger(kubeClient, stashClient, aggrClient, namespace)
+			if err := dbgr.ShowVersionInformation(); err != nil {
+				return err
+			}
 			return dbgr.DebugOperator()
 		},
 	}

--- a/pkg/debugger/operator.go
+++ b/pkg/debugger/operator.go
@@ -26,7 +26,7 @@ import (
 )
 
 func (opt *options) getOperatorPod() (*core.Pod, error) {
-	apiSvc, err := opt.aggrClient.ApiregistrationV1beta1().APIServices().Get(context.TODO(), "v1alpha1.admission.stash.appscode.com", metav1.GetOptions{})
+	apiSvc, err := opt.aggrClient.ApiregistrationV1().APIServices().Get(context.TODO(), "v1alpha1.admission.stash.appscode.com", metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Emruz Hossain <emruz@appscode.com>

APIService v1beta1 API has been removed in Kubernetes v1.22.x.

Ref: https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/#api-changes